### PR TITLE
Branchless index update in find_gte()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,11 +358,10 @@ impl<T: Ord> OrderedCollection<T> {
             };
 
             // safe because i < self.items.len()
-            i = if x <= unsafe { self.items.get_unchecked(i) }.borrow() {
-                2 * i + 1
-            } else {
-                2 * i + 2
-            };
+            let value = unsafe { self.items.get_unchecked(i) }.borrow();
+            // using branchless index update. At the moment compiler cannot reliably tranform
+            // if expressions to branchless instructions like `cmov` and `setb`
+            i = 2 * i + 1 + usize::from(x > value);
         }
 
         // we want ffs(~(i + 1))


### PR DESCRIPTION
Hi! 👋

I've run benchmarks and find one low hanging fruit how to make `find_gte()` significantly faster for most of the benchmarks especially for L1/L2 workloads.

Turns out `find_gte()` isn't fully branchless. If you run `toplev` from [pmu-tools](https://github.com/andikleen/pmu-tools) you'll find that branch misprediction is the main bottleneck.

```console
$ toplev -l1 -- taskset -c 0 target/release/deps/ordsearch-1d2dac6f589f3ed6 --bench "this::search::u32::l1"
C0    FE             Frontend_Bound   % Slots                      22.4   [33.0%]
        This category represents fraction of slots where the
        processor's Frontend undersupplies its Backend...
        Sampling events:  frontend_retired.latency_ge_4:pp
C0    BAD            Bad_Speculation  % Slots                      51.7   [33.0%]<==
        This category represents fraction of slots wasted due to
        incorrect speculations...
C0-T0 MUX                             %                            33.00
        PerfMon Event Multiplexing accuracy indicator
C0-T1 MUX                             %                            33.00
```

Digging further into assembly I've found that following expression was not optimized by the compiler:

https://github.com/jonhoo/ordsearch/blob/140ef3cc2c137c7d825ca9a7644fcb41204916cb/src/lib.rs#L361-L365

This translates into:

```asm
cmpl                %edx, (%rcx)
jae                 "test::bench::Bencher::iter::h37ad8e2219c23fd2+0x530"
leaq                0x2(%rax,%rax), %rax
cmpq                %r15, %rax
jb                  "test::bench::Bencher::iter::h37ad8e2219c23fd2+0x53a"
leaq                0x1(%rax), %rdx
```

Usually compiler is able to optimize such code using `cmov` or `seta`/`setb` instructions ([example](https://godbolt.org/z/K6zn6qWs3)). But for whatever reason it doesn't in this case. Solution is quite simple:

```rust
i = 2 * i + 1 + usize::from(x > value);
```

The results:

```diff
 name                            original ns/iter  branchless ns/iter  diff ns/iter   diff %  speedup
 b::this::search::u32::l1        52                17                           -35  -67.31%   x 3.06
 b::this::search::u32::l1_dup    36                18                           -18  -50.00%   x 2.00
 b::this::search::u32::l2        68                41                           -27  -39.71%   x 1.66
 b::this::search::u32::l2_dup    60                35                           -25  -41.67%   x 1.71
 b::this::search::u32::l3        256               177                          -79  -30.86%   x 1.45
 b::this::search::u32::l3_dup    243               177                          -66  -27.16%   x 1.37
 b::this::search::u8::l1         37                16                           -21  -56.76%   x 2.31
 b::this::search::u8::l1_dup     25                18                            -7  -28.00%   x 1.39
 b::this::search::u8::l2         39                36                            -3   -7.69%   x 1.08
 b::this::search::u8::l2_dup     28                33                             5   17.86%   x 0.85
 b::this::search::u8::l3         30                91                            61  203.33%   x 0.33
 b::this::search::u8::l3_dup     45                68                            23   51.11%   x 0.66
 b::this::search::usize::l1      56                17                           -39  -69.64%   x 3.29
 b::this::search::usize::l1_dup  32                16                           -16  -50.00%   x 2.00
 b::this::search::usize::l2      70                38                           -32  -45.71%   x 1.84
 b::this::search::usize::l2_dup  57                38                           -19  -33.33%   x 1.50
 b::this::search::usize::l3      303               279                          -24   -7.92%   x 1.09
 b::this::search::usize::l3_dup  303               290                          -13   -4.29%   x 1.04
```

Unfortunately, 3 benchmarks are become worse (`u8::l2_dup`, `u8::l3`, `u8::l3_dup`). I still can't figure out why. Maybe it's some unaligned memory access issue because of `u8` small size. `toplev` says now the benchmark is L1 memory Bound.

```
FE             Frontend_Bound.Fetch_Latency.MS_Switches       % Clocks                      1.8   [ 2.0%]
        This metric estimates the fraction of cycles when the CPU
        was stalled due to switches of uop delivery to the Microcode
        Sequencer (MS)...
        Sampling events:  idq.ms_switches
RET            Retiring.Heavy_Operations.Microcode_Sequencer  % Slots                       1.9   [ 2.0%]
        This metric represents fraction of slots the CPU was
        retiring uops fetched by the Microcode Sequencer (MS) unit...
        Sampling events:  idq.ms_uops
BAD            Bad_Speculation.Machine_Clears                 % Slots                       0.1   [ 2.0%]
        This metric represents fraction of slots the CPU has wasted
        due to Machine Clears...
        Sampling events:  machine_clears.count
BE/Mem         Backend_Bound.Memory_Bound                     % Slots                      58.6   [ 2.0%]
BE/Core        Backend_Bound.Core_Bound                       % Slots                      25.6   [ 2.0%]
BE             Backend_Bound                                  % Slots                      84.3   [ 2.0%]
        This category represents fraction of slots where no uops are
        being delivered due to a lack of required resources for
        accepting new uops in the Backend...
BE/Mem         Backend_Bound.Memory_Bound.L1_Bound            % Stalls                     30.1   [ 2.0%]<==
        This metric estimates how often the CPU was stalled without
        loads missing the L1 data cache...
        Sampling events:  mem_load_retired.l1_hit:pp mem_load_retired.fb_hit:pp
BE/Mem         Backend_Bound.Memory_Bound.L2_Bound            % Stalls                     13.7   [ 2.0%]
        This metric estimates how often the CPU was stalled due to
        L2 cache accesses by loads...
        Sampling events:  mem_load_retired.l2_hit:pp
BE/Mem         Backend_Bound.Memory_Bound.L3_Bound            % Stalls                     14.0   [ 2.0%]
        This metric estimates how often the CPU was stalled due to
        loads accesses to L3 cache or contended with a sibling Core...
        Sampling events:  mem_load_retired.l3_hit:pp
BE/Core        Backend_Bound.Core_Bound.Ports_Utilization     % Clocks                     29.7   [ 2.0%]
        This metric estimates fraction of cycles the CPU performance
        was potentially limited due to Core computation issues (non
        divider-related)...
MUX                                                           %                             2.00
        PerfMon Event Multiplexing accuracy indicator
```

But at least maybe someone can reproduce my results. And hey... half of the benchmarks are now faster than `sorted_vec` 😀, before the change all of them were slower.

```
 name                   sorted_vec ns/iter  branchless ns/iter  diff ns/iter   diff %  speedup
 search::u32::l1        54                  18                           -36  -66.67%   x 3.00
 search::u32::l1_dup    29                  17                           -12  -41.38%   x 1.71
 search::u32::l2        73                  41                           -32  -43.84%   x 1.78
 search::u32::l2_dup    48                  41                            -7  -14.58%   x 1.17
 search::u32::l3        146                 195                           49   33.56%   x 0.75
 search::u32::l3_dup    122                 208                           86   70.49%   x 0.59
 search::u8::l1         32                  17                           -15  -46.88%   x 1.88
 search::u8::l1_dup     20                  17                            -3  -15.00%   x 1.18
 search::u8::l2         28                  38                            10   35.71%   x 0.74
 search::u8::l2_dup     19                  53                            34  178.95%   x 0.36
 search::u8::l3         13                  97                            84  646.15%   x 0.13
 search::u8::l3_dup     19                  72                            53  278.95%   x 0.26
 search::usize::l1      53                  18                           -35  -66.04%   x 2.94
 search::usize::l1_dup  29                  18                           -11  -37.93%   x 1.61
 search::usize::l2      70                  42                           -28  -40.00%   x 1.67
 search::usize::l2_dup  48                  41                            -7  -14.58%   x 1.17
 search::usize::l3      171                 281                          110   64.33%   x 0.61
 search::usize::l3_dup  140                 320                          180  128.57%   x 0.44
````

The benchmark results are from `Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz`