### PR TITLE
More robust benchmarks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,10 +552,21 @@ mod b {
         ($t:ident, $v:ident) => {
             mod $v {
                 use super::*;
+                /// `dup()` and `nodup()` must be not inlined to make sure
+                /// we will have the same machine code for different sizes of a test payload
+                #[inline(never)]
                 fn nodup(c: Cache, b: &mut Bencher) {
                     let mk = concat_idents!(make_, $t);
                     let s = concat_idents!(search_, $t);
                     let mapper = concat_idents!(nodup_, $v);
+                    bench_search!(c, mk, s, mapper, b);
+                }
+
+                #[inline(never)]
+                fn dup(c: Cache, b: &mut Bencher) {
+                    let mk = concat_idents!(make_, $t);
+                    let s = concat_idents!(search_, $t);
+                    let mapper = concat_idents!(dup_, $v);
                     bench_search!(c, mk, s, mapper, b);
                 }
 
@@ -572,13 +583,6 @@ mod b {
                 #[bench]
                 fn l3(b: &mut Bencher) {
                     nodup(Cache::L3, b);
-                }
-
-                fn dup(c: Cache, b: &mut Bencher) {
-                    let mk = concat_idents!(make_, $t);
-                    let s = concat_idents!(search_, $t);
-                    let mapper = concat_idents!(dup_, $v);
-                    bench_search!(c, mk, s, mapper, b);
                 }
 
                 #[bench]
@@ -648,7 +652,7 @@ mod b {
                 // Lookup the whole range to get 50% hits and 50% misses.
                 let x = $mapper(r % size);
 
-                black_box($search(&c, x).is_some());
+                black_box($search(&c, x));
             });
         };
     }


### PR DESCRIPTION
Hi, there 👋

This PR contains two changes that I believe will make benchmarks more robust. Those suggestions are debatable, so feel free to close PR if it doesn't align with your vision.

1. I made `dup()`/`nodup()` methods as `#[inline(never)]`. At the moment they are not inlined by the compiler, but this can change under variety of factors. If they will be inlined, this can create situation when compiler will generate different machine code for the different payload sizes (unroll loops by a different factor etc.). Although this can show better benchmarking results, this strategy is not representative of real applications IMO, because it's almost never the case that we know the size of a payload at the compile time.
2. I removed `is_some()` from following code
   https://github.com/jonhoo/ordsearch/blob/140ef3cc2c137c7d825ca9a7644fcb41204916cb/src/lib.rs#L651
   In this case `find_gte()` as actually inlined by the compiler.
   ```console
   $ nm target/release/deps/ordsearch-25de5d28a523d3c2 | rustfilt | grep "find_gte" | wc -l
       0
   ```
   Which in turn allows the compiler to eliminate some of those final computations:
   https://github.com/jonhoo/ordsearch/blob/140ef3cc2c137c7d825ca9a7644fcb41204916cb/src/lib.rs#L371-L376
   this can be demonstrated with [this simple example](https://godbolt.org/z/nGoWeq8d3) on godblot. Again this is debatable as it more about what we want the benchmarks to show. But IMO it's better for benchmarks to be more representative of general case when possible.

Difference after changes:

```
 name                                  before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 b::btreeset::search::u32::l1          45              44                       -1   -2.22%   x 1.02
 b::btreeset::search::u32::l1_dup      31              34                        3    9.68%   x 0.91
 b::btreeset::search::u32::l2          63              64                        1    1.59%   x 0.98
 b::btreeset::search::u32::l2_dup      43              43                        0    0.00%   x 1.00
 b::btreeset::search::u32::l3          234             246                      12    5.13%   x 0.95
 b::btreeset::search::u32::l3_dup      120             127                       7    5.83%   x 0.94
 b::btreeset::search::u8::l1           32              31                       -1   -3.12%   x 1.03
 b::btreeset::search::u8::l1_dup       25              25                        0    0.00%   x 1.00
 b::btreeset::search::u8::l2           30              28                       -2   -6.67%   x 1.07
 b::btreeset::search::u8::l2_dup       25              25                        0    0.00%   x 1.00
 b::btreeset::search::u8::l3           22              21                       -1   -4.55%   x 1.05
 b::btreeset::search::u8::l3_dup       25              26                        1    4.00%   x 0.96
 b::btreeset::search::usize::l1        45              44                       -1   -2.22%   x 1.02
 b::btreeset::search::usize::l1_dup    30              30                        0    0.00%   x 1.00
 b::btreeset::search::usize::l2        64              62                       -2   -3.12%   x 1.03
 b::btreeset::search::usize::l2_dup    46              44                       -2   -4.35%   x 1.05
 b::btreeset::search::usize::l3        285             278                      -7   -2.46%   x 1.03
 b::btreeset::search::usize::l3_dup    155             150                      -5   -3.23%   x 1.03
 b::sorted_vec::search::u32::l1        47              48                        1    2.13%   x 0.98
 b::sorted_vec::search::u32::l1_dup    29              26                       -3  -10.34%   x 1.12
 b::sorted_vec::search::u32::l2        65              64                       -1   -1.54%   x 1.02
 b::sorted_vec::search::u32::l2_dup    47              44                       -3   -6.38%   x 1.07
 b::sorted_vec::search::u32::l3        141             125                     -16  -11.35%   x 1.13
 b::sorted_vec::search::u32::l3_dup    106             107                       1    0.94%   x 0.99
 b::sorted_vec::search::u8::l1         29              30                        1    3.45%   x 0.97
 b::sorted_vec::search::u8::l1_dup     17              18                        1    5.88%   x 0.94
 b::sorted_vec::search::u8::l2         23              25                        2    8.70%   x 0.92
 b::sorted_vec::search::u8::l2_dup     17              17                        0    0.00%   x 1.00
 b::sorted_vec::search::u8::l3         12              12                        0    0.00%   x 1.00
 b::sorted_vec::search::u8::l3_dup     16              17                        1    6.25%   x 0.94
 b::sorted_vec::search::usize::l1      49              45                       -4   -8.16%   x 1.09
 b::sorted_vec::search::usize::l1_dup  26              26                        0    0.00%   x 1.00
 b::sorted_vec::search::usize::l2      65              65                        0    0.00%   x 1.00
 b::sorted_vec::search::usize::l2_dup  50              41                       -9  -18.00%   x 1.22
 b::sorted_vec::search::usize::l3      150             149                      -1   -0.67%   x 1.01
 b::sorted_vec::search::usize::l3_dup  120             121                       1    0.83%   x 0.99
 b::this::search::u32::l1              49              50                        1    2.04%   x 0.98
 b::this::search::u32::l1_dup          38              35                       -3   -7.89%   x 1.09
 b::this::search::u32::l2              66              69                        3    4.55%   x 0.96
 b::this::search::u32::l2_dup          56              58                        2    3.57%   x 0.97
 b::this::search::u32::l3              234             242                       8    3.42%   x 0.97
 b::this::search::u32::l3_dup          249             221                     -28  -11.24%   x 1.13
 b::this::search::u8::l1               37              36                       -1   -2.70%   x 1.03
 b::this::search::u8::l1_dup           24              23                       -1   -4.17%   x 1.04
 b::this::search::u8::l2               40              42                        2    5.00%   x 0.95
 b::this::search::u8::l2_dup           25              25                        0    0.00%   x 1.00
 b::this::search::u8::l3               29              54                       25   86.21%   x 0.54
 b::this::search::u8::l3_dup           35              36                        1    2.86%   x 0.97
 b::this::search::usize::l1            49              50                        1    2.04%   x 0.98
 b::this::search::usize::l1_dup        33              31                       -2   -6.06%   x 1.06
 b::this::search::usize::l2            68              71                        3    4.41%   x 0.96
 b::this::search::usize::l2_dup        57              57                        0    0.00%   x 1.00
 b::this::search::usize::l3            307             299                      -8   -2.61%   x 1.03
 b::this::search::usize::l3_dup        304             309                       5    1.64%   x 0.98
```

In most cases there is no significat changes, but there is one (`b::this::search::u8::l3`) where there is ~90% performance drop.

This is the same benchmark I've had problems with in #5. I'm starting to believe that there is some systematic issue with the benchmark itself. Like, for example, how one can test `u8` in L3 without duplicates? It's just not enough uniq values... The other problem is `l3` benchmarks are consistently faster that `l2` which should not be the case as `l3` have 2 orders of magnitude larger data

```
test b::this::search::u8::l2                    ... bench:          39 ns/iter (+/- 6)
test b::this::search::u8::l3                    ... bench:          30 ns/iter (+/- 6)

test b::sorted_vec::search::u8::l2              ... bench:          28 ns/iter (+/- 2)
test b::sorted_vec::search::u8::l3              ... bench:          13 ns/iter (+/- 1)

test b::btreeset::search::u8::l2                ... bench:          30 ns/iter (+/- 2)
test b::btreeset::search::u8::l3                ... bench:          22 ns/iter (+/- 3)
```

Anyway, I will try to look into this later.