### PR TITLE
Remove unneeded references from benchmark

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -653,26 +653,27 @@ mod b {
         };
     }
 
-    fn make_this<T: Ord>(v: &mut Vec<T>) -> OrderedCollection<&T> {
-        OrderedCollection::from_slice(v)
+    fn make_this<T: Ord + Copy>(v: &mut Vec<T>) -> OrderedCollection<T> {
+        v.sort_unstable();
+        OrderedCollection::from_sorted_iter(v.into_iter().map(|x| *x))
     }
 
-    fn search_this<'a, T: Ord>(c: &OrderedCollection<&'a T>, x: T) -> Option<&'a T> {
-        c.find_gte(x).map(|v| &**v)
+    fn search_this<T: Ord>(c: &OrderedCollection<T>, x: T) -> Option<&T> {
+        c.find_gte(x).map(|v| &*v)
     }
 
     benches!(this);
 
-    fn make_btreeset<T: Ord>(v: &mut Vec<T>) -> BTreeSet<&T> {
+    fn make_btreeset<T: Ord + Copy>(v: &mut Vec<T>) -> BTreeSet<T> {
         use std::iter::FromIterator;
-        BTreeSet::from_iter(v.iter())
+        BTreeSet::from_iter(v.iter().copied())
     }
 
-    fn search_btreeset<'a, T: Ord>(c: &BTreeSet<&'a T>, x: T) -> Option<&'a T> {
+    fn search_btreeset<T: Ord>(c: &BTreeSet<T>, x: T) -> Option<&T> {
         use std::collections::Bound;
         c.range((Bound::Included(x), Bound::Unbounded))
             .next()
-            .map(|v| &**v)
+            .map(|v| &*v)
     }
 
     benches!(btreeset);


### PR DESCRIPTION
Benchmark payload in case of `OrderedCollection` and `BTreeSet` contains references while `sorted_vec` operate on primitives directly. This is incorrect, because it punishes `OrderedCollection` and `BTreeSet` with one more level of memory indirection.

In this PR I've removed references from `make_this()` and `make_btreeset()` payload generators.

Performance improved significantly (all results are reported including changes from #5)

Changes across all benchmarks:

```console
$ cargo benchcmp --threshold 5 original wo_reference
 name                                      original ns/iter  wo_reference ns/iter  diff ns/iter   diff %  speedup
 b::btreeset::construction::u32::l1        54,750            46,120                      -8,630  -15.76%   x 1.19
 b::btreeset::construction::u32::l2        635,738           550,974                    -84,764  -13.33%   x 1.15
 b::btreeset::construction::u32::l2_dup    516,775           470,001                    -46,774   -9.05%   x 1.10
 b::btreeset::construction::u8::l1         42,028            37,353                      -4,675  -11.12%   x 1.13
 b::btreeset::construction::usize::l1_dup  38,881            36,248                      -2,633   -6.77%   x 1.07
 b::btreeset::construction::usize::l2      651,426           553,164                    -98,262  -15.08%   x 1.18
 b::btreeset::construction::usize::l2_dup  532,046           479,678                    -52,368   -9.84%   x 1.11
 b::btreeset::search::u32::l1              45                42                              -3   -6.67%   x 1.07
 b::btreeset::search::u32::l2              62                58                              -4   -6.45%   x 1.07
 b::btreeset::search::u32::l3              229               111                           -118  -51.53%   x 2.06
 b::btreeset::search::u32::l3_dup          122               74                             -48  -39.34%   x 1.65
 b::btreeset::search::u8::l2_dup           27                24                              -3  -11.11%   x 1.12
 b::btreeset::search::u8::l3_dup           24                27                               3   12.50%   x 0.89
 b::btreeset::search::usize::l2            64                58                              -6   -9.38%   x 1.10
 b::btreeset::search::usize::l3            280               151                           -129  -46.07%   x 1.85
 b::btreeset::search::usize::l3_dup        154               78                             -76  -49.35%   x 1.97
 b::sorted_vec::search::u32::l1_dup        29                27                              -2   -6.90%   x 1.07
 b::sorted_vec::search::u8::l1_dup         18                19                               1    5.56%   x 0.95
 b::sorted_vec::search::u8::l2             23                28                               5   21.74%   x 0.82
 b::sorted_vec::search::u8::l3             11                12                               1    9.09%   x 0.92
 b::sorted_vec::search::u8::l3_dup         17                16                              -1   -5.88%   x 1.06
 b::sorted_vec::search::usize::l1_dup      28                31                               3   10.71%   x 0.90
 b::this::search::u32::l1                  19                14                              -5  -26.32%   x 1.36
 b::this::search::u32::l1_dup              16                14                              -2  -12.50%   x 1.14
 b::this::search::u32::l2                  36                25                             -11  -30.56%   x 1.44
 b::this::search::u32::l2_dup              36                25                             -11  -30.56%   x 1.44
 b::this::search::u32::l3                  166               38                            -128  -77.11%   x 4.37
 b::this::search::u32::l3_dup              181               36                            -145  -80.11%   x 5.03
 b::this::search::u8::l1                   16                14                              -2  -12.50%   x 1.14
 b::this::search::u8::l1_dup               16                14                              -2  -12.50%   x 1.14
 b::this::search::u8::l2                   35                25                             -10  -28.57%   x 1.40
 b::this::search::u8::l2_dup               34                28                              -6  -17.65%   x 1.21
 b::this::search::u8::l3                   91                33                             -58  -63.74%   x 2.76
 b::this::search::u8::l3_dup               80                36                             -44  -55.00%   x 2.22
 b::this::search::usize::l1                19                13                              -6  -31.58%   x 1.46
 b::this::search::usize::l1_dup            16                12                              -4  -25.00%   x 1.33
 b::this::search::usize::l2                37                25                             -12  -32.43%   x 1.48
 b::this::search::usize::l2_dup            37                24                             -13  -35.14%   x 1.54
 b::this::search::usize::l3                267               53                            -214  -80.15%   x 5.04
 b::this::search::usize::l3_dup            285               48                            -237  -83.16%   x 5.94
```

Now `OrderedCollection` is consistently faster than `BTreeSet` and `sorted_vec` across almost all benchmarks :

`BTreeSet` to `OrderedCollection`
```console
 name                      btreeset ns/iter  this ns/iter  diff ns/iter   diff %  speedup
 b::search::u32::l1        42                14                     -28  -66.67%   x 3.00
 b::search::u32::l1_dup    29                14                     -15  -51.72%   x 2.07
 b::search::u32::l2        58                25                     -33  -56.90%   x 2.32
 b::search::u32::l2_dup    41                25                     -16  -39.02%   x 1.64
 b::search::u32::l3        111               38                     -73  -65.77%   x 2.92
 b::search::u32::l3_dup    74                36                     -38  -51.35%   x 2.06
 b::search::u8::l1         31                14                     -17  -54.84%   x 2.21
 b::search::u8::l1_dup     24                14                     -10  -41.67%   x 1.71
 b::search::u8::l2         29                25                      -4  -13.79%   x 1.16
 b::search::u8::l2_dup     24                28                       4   16.67%   x 0.86
 b::search::u8::l3         21                33                      12   57.14%   x 0.64
 b::search::u8::l3_dup     27                36                       9   33.33%   x 0.75
 b::search::usize::l1      43                13                     -30  -69.77%   x 3.31
 b::search::usize::l1_dup  29                12                     -17  -58.62%   x 2.42
 b::search::usize::l2      58                25                     -33  -56.90%   x 2.32
 b::search::usize::l2_dup  43                24                     -19  -44.19%   x 1.79
 b::search::usize::l3      151               53                     -98  -64.90%   x 2.85
 b::search::usize::l3_dup  78                48                     -30  -38.46%   x 1.62
```

`sorted_vec` to `OrderedCollection`

```console
 name                      sorted_vec ns/iter  this ns/iter  diff ns/iter   diff %  speedup
 b::search::u32::l1        48                  14                     -34  -70.83%   x 3.43
 b::search::u32::l1_dup    27                  14                     -13  -48.15%   x 1.93
 b::search::u32::l2        64                  25                     -39  -60.94%   x 2.56
 b::search::u32::l2_dup    44                  25                     -19  -43.18%   x 1.76
 b::search::u32::l3        126                 38                     -88  -69.84%   x 3.32
 b::search::u32::l3_dup    106                 36                     -70  -66.04%   x 2.94
 b::search::u8::l1         33                  14                     -19  -57.58%   x 2.36
 b::search::u8::l1_dup     19                  14                      -5  -26.32%   x 1.36
 b::search::u8::l2         28                  25                      -3  -10.71%   x 1.12
 b::search::u8::l2_dup     17                  28                      11   64.71%   x 0.61
 b::search::u8::l3         12                  33                      21  175.00%   x 0.36
 b::search::u8::l3_dup     16                  36                      20  125.00%   x 0.44
 b::search::usize::l1      48                  13                     -35  -72.92%   x 3.69
 b::search::usize::l1_dup  31                  12                     -19  -61.29%   x 2.58
 b::search::usize::l2      65                  25                     -40  -61.54%   x 2.60
 b::search::usize::l2_dup  46                  24                     -22  -47.83%   x 1.92
 b::search::usize::l3      144                 53                     -91  -63.19%   x 2.72
 b::search::usize::l3_dup  120                 48                     -72  -60.00%   x 2.50
```

There is objective reason why `OrderedCollection` is still slower on `l2_dup`, `l3` and `l3_dup`. But I will file a different PR on this. It's more like benchmark strategy problem than code problem, in my opinion.