### PR TITLE
Minor followup changes on previous PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 [![Documentation](https://docs.rs/ordsearch/badge.svg)](https://docs.rs/ordsearch/)
 [![Build Status](https://travis-ci.org/jonhoo/ordsearch.svg?branch=master)](https://travis-ci.org/jonhoo/ordsearch)
 
-> NOTE: This crate is generally *slower* than using `Vec::binary_search` over a pre-sorted
-> vector, contrary to the claims in the referenced paper, and is mainly presented for
-> curiosity's sake at this point.
-
 This crate provides a data structure for approximate lookups in ordered collections.
 
 More concretely, given a set `A` of `n` values, and a query value `x`, this library provides an
@@ -51,65 +47,63 @@ performance gain seems to be best on Intel processors, and is smaller since the 
 recent improvement to [SliceExt::binary_search
 performance](https://github.com/rust-lang/rust/pull/45333).
 
-Below are [summarized](https://github.com/BurntSushi/cargo-benchcmp) results from an AMD
-ThreadRipper 2600X CPU run with:
+Below are [summarized](https://github.com/BurntSushi/cargo-benchcmp) results from an Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz CPU run with:
 
 ```console
 $ rustc +nightly --version
-rustc 1.28.0-nightly (e3bf634e0 2018-06-28)
-$ env CARGO_INCREMENTAL=0 RUSTFLAGS='-C target-cpu=native -C lto=thin' cargo +nightly bench --features nightly
+rustc 1.73.0-nightly (33a2c2487 2023-07-12)
+$ env CARGO_INCREMENTAL=0 RUSTFLAGS='-C target-cpu=native' cargo +nightly bench --features nightly
 ```
 
 Compared to binary search over a sorted vector:
 
 ```diff,ignore
  name           sorted_vec ns/iter  this ns/iter  diff ns/iter   diff %  speedup
--u32::l1        49                  54                       5   10.20%   x 0.91
-+u32::l1_dup    40                  35                      -5  -12.50%   x 1.14
--u32::l2        63                  72                       9   14.29%   x 0.88
-+u32::l2_dup    64                  62                      -2   -3.12%   x 1.03
--u32::l3        120                 273                    153  127.50%   x 0.44
--u32::l3_dup    117                 219                    102   87.18%   x 0.53
-+u8::l1         42                  37                      -5  -11.90%   x 1.14
-+u8::l1_dup     29                  28                      -1   -3.45%   x 1.04
-+u8::l2         43                  49                       6   13.95%   x 0.88
--u8::l2_dup     33                  35                       2    6.06%   x 0.94
--u8::l3         45                  66                      21   46.67%   x 0.68
--u8::l3_dup     35                  51                      16   45.71%   x 0.69
--usize::l1      49                  54                       5   10.20%   x 0.91
-+usize::l1_dup  38                  37                      -1   -2.63%   x 1.03
--usize::l2      65                  76                      11   16.92%   x 0.86
-+usize::l2_dup  65                  64                      -1   -1.54%   x 1.02
--usize::l3      141                 303                    162  114.89%   x 0.47
--usize::l3_dup  140                 274                    134   95.71%   x 0.51
++u32::l1        46                  15                     -31  -67.39%   x 3.07
++u32::l1_dup    30                  14                     -16  -53.33%   x 2.14
++u32::l2        66                  26                     -40  -60.61%   x 2.54
++u32::l2_dup    44                  27                     -17  -38.64%   x 1.63
++u32::l3        129                 37                     -92  -71.32%   x 3.49
++u32::l3_dup    109                 37                     -72  -66.06%   x 2.95
++u8::l1         30                  16                     -14  -46.67%   x 1.88
++u8::l1_dup     20                  14                      -6  -30.00%   x 1.43
+-u8::l2         26                  29                       3   11.54%   x 0.90
+-u8::l2_dup     19                  26                       7   36.84%   x 0.73
+-u8::l3         13                  36                      23  176.92%   x 0.36
+-u8::l3_dup     17                  31                      14   82.35%   x 0.55
++usize::l1      49                  13                     -36  -73.47%   x 3.77
++usize::l1_dup  30                  15                     -15  -50.00%   x 2.00
++usize::l2      68                  25                     -43  -63.24%   x 2.72
++usize::l2_dup  47                  27                     -20  -42.55%   x 1.74
++usize::l3      155                 52                    -103  -66.45%   x 2.98
++usize::l3_dup  157                 61                     -96  -61.15%   x 2.57
 ```
 
 Compared to a `BTreeSet`:
 
 ```diff,ignore
  name           btreeset ns/iter  this ns/iter  diff ns/iter   diff %  speedup
-+u32::l1        68                54                     -14  -20.59%   x 1.26
-+u32::l1_dup    45                35                     -10  -22.22%   x 1.29
-+u32::l2        88                72                     -16  -18.18%   x 1.22
--u32::l2_dup    61                62                       1    1.64%   x 0.98
-+u32::l3        346               273                    -73  -21.10%   x 1.27
--u32::l3_dup    136               219                     83   61.03%   x 0.62
-+u8::l1         45                37                      -8  -17.78%   x 1.22
-+u8::l1_dup     31                28                      -3   -9.68%   x 1.11
--u8::l2         44                49                       5   11.36%   x 0.90
--u8::l2_dup     31                35                       4   12.90%   x 0.89
--u8::l3         43                66                      23   53.49%   x 0.65
--u8::l3_dup     30                51                      21   70.00%   x 0.59
-+usize::l1      67                54                     -13  -19.40%   x 1.24
-+usize::l1_dup  44                37                      -7  -15.91%   x 1.19
-+usize::l2      89                76                     -13  -14.61%   x 1.17
--usize::l2_dup  60                64                       4    6.67%   x 0.94
-+usize::l3      393               303                    -90  -22.90%   x 1.30
--usize::l3_dup  163               274                    111   68.10%   x 0.59
++u32::l1        49                15                     -34  -69.39%   x 3.27
++u32::l1_dup    30                14                     -16  -53.33%   x 2.14
++u32::l2        61                26                     -35  -57.38%   x 2.35
++u32::l2_dup    43                27                     -16  -37.21%   x 1.59
++u32::l3        125               37                     -88  -70.40%   x 3.38
++u32::l3_dup    83                37                     -46  -55.42%   x 2.24
++u8::l1         34                16                     -18  -52.94%   x 2.12
++u8::l1_dup     24                14                     -10  -41.67%   x 1.71
++u8::l2         30                29                      -1   -3.33%   x 1.03
++u8::l2_dup     27                26                      -1   -3.70%   x 1.04
+-u8::l3         23                36                      13   56.52%   x 0.64
+-u8::l3_dup     26                31                       5   19.23%   x 0.84
++usize::l1      48                13                     -35  -72.92%   x 3.69
++usize::l1_dup  31                15                     -16  -51.61%   x 2.07
++usize::l2      63                25                     -38  -60.32%   x 2.52
++usize::l2_dup  42                27                     -15  -35.71%   x 1.56
++usize::l3      166               52                    -114  -68.67%   x 3.19
++usize::l3_dup  80                61                     -19  -23.75%   x 1.31
 ```
 
 ## Future work
 
  - [ ] Implement aligned operation: https://github.com/patmorin/arraylayout/blob/3f20174a2a0ab52c6f37f2ea87d087307f19b5ee/src/eytzinger_array.h#L204
  - [ ] Implement deep prefetching for large `T`: https://github.com/patmorin/arraylayout/blob/3f20174a2a0ab52c6f37f2ea87d087307f19b5ee/src/eytzinger_array.h#L128
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,17 @@ mod b {
         ($t:ident, $v:ident) => {
             mod $v {
                 use super::*;
+
+                /// `dup()` and `nodup()` must be not inlined to make sure
+                /// we will have the same machine code for different sizes of a test payload
+                #[inline(never)]
+                fn dup(c: Cache, b: &mut Bencher) {
+                    let mk = concat_idents!(make_, $t);
+                    let mapper = concat_idents!(dup_, $v);
+                    bench_construction!(c, mk, mapper, b);
+                }
+
+                #[inline(never)]
                 fn nodup(c: Cache, b: &mut Bencher) {
                     let mk = concat_idents!(make_, $t);
                     let mapper = concat_idents!(nodup_, $v);
@@ -526,12 +537,6 @@ mod b {
                 #[bench]
                 fn l2(b: &mut Bencher) {
                     nodup(Cache::L2, b);
-                }
-
-                fn dup(c: Cache, b: &mut Bencher) {
-                    let mk = concat_idents!(make_, $t);
-                    let mapper = concat_idents!(dup_, $v);
-                    bench_construction!(c, mk, mapper, b);
                 }
 
                 #[bench]
@@ -624,7 +629,7 @@ mod b {
 
     macro_rules! bench_construction {
         ($cache:expr, $make:ident, $mapper:ident, $b:ident) => {
-            let size = $cache.size();
+            let size = black_box($cache.size());
             let mut v: Vec<_> = (0..size).map(&$mapper).collect();
             let mut r = 0usize;
 
@@ -640,7 +645,7 @@ mod b {
 
     macro_rules! bench_search {
         ($cache:expr, $make:ident, $search:ident, $mapper:ident, $b:ident) => {
-            let size = $cache.size();
+            let size = black_box($cache.size());
             let mut v: Vec<_> = (0..size).map(&$mapper).collect();
             let mut r = 0usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,7 +663,7 @@ mod b {
 
     fn make_this<T: Ord + Copy>(v: &mut Vec<T>) -> OrderedCollection<T> {
         v.sort_unstable();
-        OrderedCollection::from_sorted_iter(v.into_iter().map(|x| *x))
+        OrderedCollection::from_sorted_iter(v.iter().copied())
     }
 
     fn search_this<T: Ord>(c: &OrderedCollection<T>, x: T) -> Option<&T> {


### PR DESCRIPTION
This PR contains minor code review suggestions and README updates based on

- https://github.com/jonhoo/ordsearch/pull/5
- https://github.com/jonhoo/ordsearch/pull/6
- https://github.com/jonhoo/ordsearch/pull/7

Contents:

- fixed https://github.com/jonhoo/ordsearch/pull/7#discussion_r1285197899
- fixed https://github.com/jonhoo/ordsearch/pull/6#pullrequestreview-1564123061
- fixed https://github.com/jonhoo/ordsearch/pull/6#issuecomment-1666813740
- README updated: https://github.com/jonhoo/ordsearch/pull/7#pullrequestreview-1564126244.
   - update performance data
   - update running instructions: `-C lto=thin` produces following error:
      ```
      error: options `-C embed-bitcode=no` and `-C lto` are incompatible

      error: could not compile `ordsearch` (lib test) due to previous error
      ```
   - remove "generally slower" notice. It's not true anymore 😀