### PR TITLE
Fixing UB in construction code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,9 +177,12 @@ where
     eytzinger_walk(v, iter, 2 * i + 1);
 
     // put data at the root
-    // we know the get_unchecked_mut and unwrap below are safe because we set the Vec's capacity to
+    // we know the pointer arithmetics below is safe because we set the Vec's capacity to
     // the length of the iterator.
-    *unsafe { v.get_unchecked_mut(i) } = iter.next().unwrap();
+    let value = iter.next().unwrap();
+    unsafe {
+        v.as_mut_ptr().add(i).write(value);
+    }
 
     // visit right child
     eytzinger_walk(v, iter, 2 * i + 2);


### PR DESCRIPTION
As stated in #16 miri complains about undefined behavior in `eytzinger_walk()`. As far as I can tell this is indeed UB because `get_unchecked_mut()` is UB when accessing out-of-bounds index ([even without dereferencing](https://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked_mut)). Out-of-bounds I interpret as "after length", not "after capacity".

The issue goes away if appropriate `resize()` call has been done on a `Vec` before writing elements to it. This agrees with the hypothesis that uninitialized vector is the issue.

I rewrite construction code using `MaybeUninit`, `resize_with` (which is zero cost in conjunction with `MaybeUninit`) and `mem::transmute` to mitigate this issue. `mem::transmute` may seems scary but it is the analog of `set_len()` in old code.

The alternative would be to fill the Vec with default values, but it does have performance impact.