### PR TITLE
Using high 32 bits as a source of entropy

### DIFF
--- a/benches/search_comparison.rs
+++ b/benches/search_comparison.rs
@@ -270,7 +270,7 @@ where
     std::iter::from_fn(move || {
         // LCG constants from https://en.wikipedia.org/wiki/Numerical_Recipes.
         seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
-        let r = seed % max;
+        let r = (seed >> 32) % max;
 
         Some(T::try_from(r).unwrap())
     })


### PR DESCRIPTION
Ordsearch uses LCG parameters proposed by Knuth and Lewis for generating payload and queries for benchmarking purposes:

https://github.com/jonhoo/ordsearch/blob/247ea1fda8c62f3ae84aef683e68c269099be401/benches/search_comparison.rs#L271-L273

Most of the power-of-two modulus LCG have peculiar problem that can be shown with the following snippet of code:

```rust
    let max_value = 8;
    let values = pseudorandom_iter::<u8>(max_value)
        .take(max_value * 10)
        .collect::<Vec<_>>();
    for chunk in values.chunks(max_value) {
        println!("{chunk:?}");
    }
```

Here we are generating 80 numbers in the range 0..8 and grouping them in pack of 8. The output is:

```
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
[7, 2, 1, 4, 3, 6, 5, 0]
```

The caveat is that low $k$ bits of random number have period of $2^k$. So when generating numbers in the range $0..2^k$ LCG produces strictly predictable sequences (see. [Linear congruential generator](https://en.wikipedia.org/wiki/Linear_congruential_generator#Period_length)).

This problem has 2 quite simple solutions:

- using high 32 bits as a source for generating number. It will limits dynamic range of LCG, but 32 bits are enough for out purposes. This solution is implemented in this PR ✅.
- do not use power-of-two as the end value of the range. $2^k-1$ can be used. IMO this solution is brittle, because it can not be implemented inside `pseudorandom_iter()` ❌

This change has quite serious performance consequences, especially for small payloads:

```console
$ cargo +nightly bench --bench=search_comparison --features=nightly "^Search u32/[^/]+/8$" -- -b main
Search u32/sorted_vec/8 time:   [22.415 ns 22.598 ns 22.767 ns]
                        change: [+469.06% +480.79% +493.38%] (p = 0.00 < 0.05)
                        Performance has regressed.
Search u32/btreeset/8   time:   [24.791 ns 24.986 ns 25.180 ns]
                        change: [+109.60% +112.05% +114.12%] (p = 0.00 < 0.05)
                        Performance has regressed.
Search u32/ordsearch/8  time:   [8.4515 ns 8.5341 ns 8.6305 ns]
                        change: [+32.446% +34.906% +37.226%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

All benchmarks became slower, but relatively speaking `OrderedCollection` is winning, because it has lowest penalty across all benchmarks. Binary search is almost 6 times slower for `[u32; 8]` and about 10% slower for higher payloads!

Unfortunately, at the moment I do not have access to non-virtualized Linux box to check the performance counters. Therefore, I can not produce any meaningful insights about why it's the case. But because queries are less predictable I believe now benchmarks are more representative of a real-world performance.