### PR TITLE
Some refactorings. No functional changes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,13 +112,12 @@
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(feature = "nightly", feature(concat_idents))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#[cfg(feature = "nightly")]
-extern crate test;
-
-#[cfg(test)]
-extern crate std;
 
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
+#[cfg(feature = "nightly")]
+extern crate test;
 
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -156,7 +155,7 @@ impl<T: Ord> From<Vec<T>> for OrderedCollection<T> {
     /// ```
     fn from(mut v: Vec<T>) -> OrderedCollection<T> {
         v.sort_unstable();
-        Self::from_sorted_iter(v.into_iter())
+        Self::from_sorted_iter(v)
     }
 }
 
@@ -289,12 +288,12 @@ impl<T: Ord> OrderedCollection<T> {
         let n = iter.len();
         let mut context = (Vec::with_capacity(n), iter);
         eytzinger_walk(&mut context, 0);
-        let (mut v, _) = context;
+        let (mut items, _) = context;
 
         // it's now safe to set the length, since all `n` elements have been inserted.
-        unsafe { v.set_len(n) };
+        unsafe { items.set_len(n) };
 
-        OrderedCollection { items: v }
+        OrderedCollection { items }
     }
 
     /// Construct a new `OrderedCollection` from a slice of elements.
@@ -311,7 +310,7 @@ impl<T: Ord> OrderedCollection<T> {
     /// ```
     pub fn from_slice(v: &mut [T]) -> OrderedCollection<&T> {
         v.sort_unstable();
-        OrderedCollection::from_sorted_iter(v.iter_mut().map(|x| &*x))
+        OrderedCollection::from_sorted_iter(v.iter())
     }
 
     /// Find the smallest value `v` such that `v >= x`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,15 +109,12 @@
 //!
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(feature = "nightly", feature(concat_idents))]
 #![cfg_attr(feature = "nightly", feature(core_intrinsics))]
 
 extern crate alloc;
 #[cfg(test)]
 extern crate std;
-#[cfg(feature = "nightly")]
-extern crate test;
 
 use alloc::vec::Vec;
 use core::borrow::Borrow;


### PR DESCRIPTION
Some cleanups and clippy lints fixed

- some imports reorganized
- unneeded trait bounds, lifetimes, and transformations over iterators removed
- several explanations added to the code
- removed `black_box()`. Returned from the bench function value is [automatically wrapped](https://github.com/bheisler/criterion.rs/blob/e1a8c9ab2104fbf2d15f700d0038b2675054a2c8/src/bencher.rs#L88) by criterion in `black_box()`