### PR TITLE
Draft: Experimental Tango support

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -10,8 +10,8 @@ jobs:
   bench:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: main
           path: baseline-branch

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -31,6 +31,9 @@ jobs:
             ./target/
             ./baseline-branch/target/
           key: Bench/${{ runner.os }}
+      - name: Install cargo-export
+        if: hashFiles('~/.cargo/bin/cargo-export') == ''
+        run: cargo install cargo-export --version 0.2.0
 
       - name: Building Benchmarks
         run: |

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -32,8 +32,10 @@ jobs:
             ./baseline-branch/target/
           key: Bench/${{ runner.os }}
       - name: Install cargo-export
-        if: hashFiles('~/.cargo/bin/cargo-export') == ''
-        run: cargo install cargo-export --version 0.2.0
+        run: |
+          if [ ! -f ~/.cargo/bin/cargo-export ]; then
+            cargo install cargo-export
+          fi
 
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -16,11 +16,10 @@ jobs:
           ref: main
           path: baseline-branch
 
-      - name: Prepare Environment
-        run: |
-          rustup update stable
-          rustup default stable
-          cargo install cargo-export --version 0.2.0
+      - name: Install Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cargo export target/benchmarks -- bench --bench=search_ord
           # !!!SHOULD BE FIXED AFTER MERGE TO MAIN!!!
-          # At the moment we can only test branch agains itself, because threi is no
+          # At the moment we can only test branch agains itself, because there is no
           # tango benchmarks on the main.
           # cd baseline-branch
           # cargo export target/benchmarks -- bench --bench=search_ord
@@ -47,7 +47,7 @@ jobs:
           set -eo pipefail
 
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -v -t 1 --fail-threshold 20 | tee target/benchmark.txt
+            -ot 1 --fail-threshold 10 | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,52 @@
+name: Benchmarks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+
+jobs:
+  bench:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+          path: baseline-branch
+
+      - name: Prepare Environment
+        run: |
+          rustup update stable
+          rustup default stable
+          cargo install cargo-export --version 0.2.0
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+            ./baseline-branch/target/
+          key: Bench/${{ runner.os }}
+
+      - name: Building Benchmarks
+        run: |
+          cargo export target/benchmarks -- bench --bench=search_ord
+          cd baseline-branch
+          cargo export target/benchmarks -- bench --bench=search_ord
+
+      - name: Run Benchmarks
+        run: |
+          set -eo pipefail
+
+          target/benchmarks/search_ord --color=never compare baseline-branch/target/benchmarks/search_ord \
+            -v -o -t 1 --fail-threshold 10 | tee target/benchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: benchmark.txt
+          path: target/benchmark.txt

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -47,7 +47,7 @@ jobs:
           set -eo pipefail
 
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -v -o -t 1 --fail-threshold 10 | tee target/benchmark.txt
+            -v -o -t 1 --fail-threshold 20 | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -17,9 +17,7 @@ jobs:
           path: baseline-branch
 
       - name: Install Toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -19,21 +19,10 @@ jobs:
       - name: Install Toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ./target/
-            ./baseline-branch/target/
-          key: Bench/${{ runner.os }}
-      - name: Install cargo-export
-        run: |
-          if [ ! -f ~/.cargo/bin/cargo-export ]; then
-            cargo install cargo-export
-          fi
+          tool: cargo-export
 
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -47,7 +47,7 @@ jobs:
           set -eo pipefail
 
           target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
-            -v -o -t 1 --fail-threshold 20 | tee target/benchmark.txt
+            -v -t 1 --fail-threshold 20 | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -36,14 +36,17 @@ jobs:
       - name: Building Benchmarks
         run: |
           cargo export target/benchmarks -- bench --bench=search_ord
-          cd baseline-branch
-          cargo export target/benchmarks -- bench --bench=search_ord
+          # !!!SHOULD BE FIXED AFTER MERGE TO MAIN!!!
+          # At the moment we can only test branch agains itself, because threi is no
+          # tango benchmarks on the main.
+          # cd baseline-branch
+          # cargo export target/benchmarks -- bench --bench=search_ord
 
       - name: Run Benchmarks
         run: |
           set -eo pipefail
 
-          target/benchmarks/search_ord --color=never compare baseline-branch/target/benchmarks/search_ord \
+          target/benchmarks/search_ord --color=never compare target/benchmarks/search_ord \
             -v -o -t 1 --fail-threshold 10 | tee target/benchmark.txt
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -35,14 +35,17 @@ jobs:
         if: hashFiles('~/.cargo/bin/cargo-export') == ''
         run: cargo install cargo-export --version 0.2.0
 
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
       - name: Building Benchmarks
         run: |
-          cargo export target/benchmarks -- bench --bench=search_ord
+          cargo export target/benchmarks -- bench --bench=search_ord --locked
           # !!!SHOULD BE FIXED AFTER MERGE TO MAIN!!!
           # At the moment we can only test branch agains itself, because there is no
           # tango benchmarks on the main.
           # cd baseline-branch
-          # cargo export target/benchmarks -- bench --bench=search_ord
+          # cargo export target/benchmarks -- bench --bench=search_ord --locked
 
       - name: Run Benchmarks
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "git+https://github.com/bazhenov/tango.git?branch=dev#0567e4734713155941757bc27c9318ec4c3ac15a"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#c79a3f063b8ff672a8e64ccb42331b85eaa9c795"
 dependencies = [
  "anyhow",
  "clap",
@@ -733,6 +733,7 @@ dependencies = [
  "glob-match",
  "goblin",
  "libloading",
+ "log",
  "num-traits",
  "rand",
  "scroll",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "git+https://github.com/bazhenov/tango.git?branch=dev#c79a3f063b8ff672a8e64ccb42331b85eaa9c795"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#4b44f2e3959868c7b6a5df3a7b439e9286322b65"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "git+https://github.com/bazhenov/tango.git?branch=dev#c4e59a5ba5e0828123c2fa7cb6f8f6229fbbf4a7"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#7807da3479f62f435a3b8340daf0bf6d9d0f9f28"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "git+https://github.com/bazhenov/tango.git?branch=dev#4b44f2e3959868c7b6a5df3a7b439e9286322b65"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#afcc8febc6c908cc10c1c93f1ee4efcce4b0c7db"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,16 +18,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -46,15 +100,6 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -96,6 +141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -104,8 +151,22 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -113,6 +174,21 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colorz"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc2a5df6ee18d52a36920c93a7736761c6fcffa72b9d960fd9133dd8d57c5184"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "criterion"
@@ -201,23 +277,46 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
+name = "fastrand"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cc",
+ "cfg-if",
  "libc",
+ "wasi",
+]
+
+[[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -225,6 +324,12 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -240,8 +345,14 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "is_ci"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
@@ -269,15 +380,25 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "log"
@@ -339,7 +460,14 @@ dependencies = [
  "num-traits",
  "regex",
  "serde",
+ "tango-bench",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -370,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +519,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -407,6 +571,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -440,15 +613,15 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.9"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -471,6 +644,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde"
@@ -504,6 +697,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +721,58 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tango-bench"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac960d5e0231a0e0057a194ec07cc3dabd918d31ec3a0b4f19bfa2591877d2b"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colorz",
+ "glob-match",
+ "goblin",
+ "libloading",
+ "num-traits",
+ "rand",
+ "scroll",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -531,6 +792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "walkdir"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +806,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -641,7 +914,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -650,13 +932,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -666,10 +963,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -678,10 +987,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -690,13 +1011,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,12 +57,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -136,20 +136,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -159,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.0"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -171,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
@@ -726,7 +725,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "git+https://github.com/bazhenov/tango.git?branch=dev#7807da3479f62f435a3b8340daf0bf6d9d0f9f28"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#0567e4734713155941757bc27c9318ec4c3ac15a"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,8 +726,7 @@ dependencies = [
 [[package]]
 name = "tango-bench"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac960d5e0231a0e0057a194ec07cc3dabd918d31ec3a0b4f19bfa2591877d2b"
+source = "git+https://github.com/bazhenov/tango.git?branch=dev#c4e59a5ba5e0828123c2fa7cb6f8f6229fbbf4a7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nightly = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-tango-bench = "0.2"
+tango-bench = { git = "https://github.com/bazhenov/tango.git", branch = "dev" }
 num-traits = "0.2.15"
 
 [target.'cfg(any())'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ordsearch"
 version = "0.2.5"
+autobenches = false
 
 description = "A data structure for efficient lower-bound lookups"
 readme = "README.md"
@@ -22,6 +23,7 @@ nightly = []
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+tango-bench = "0.2"
 num-traits = "0.2.15"
 
 [target.'cfg(any())'.dependencies]
@@ -30,4 +32,16 @@ regex = { version = "1.6.0", optional = true }
 
 [[bench]]
 name = "search_comparison"
+harness = false
+
+[[bench]]
+name = "search_vec"
+harness = false
+
+[[bench]]
+name = "search_ord"
+harness = false
+
+[[bench]]
+name = "search_btree"
 harness = false

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,6 +1,4 @@
-extern crate tango_bench;
-
-use std::{any::type_name, convert::TryFrom, iter, marker::PhantomData};
+use std::{any::type_name, convert::TryFrom, fmt::Debug, iter, marker::PhantomData};
 use tango_bench::{
     BenchmarkMatrix, Generator, IntoBenchmarks, MeasurementSettings, DEFAULT_SETTINGS,
 };
@@ -50,7 +48,7 @@ where
 
 impl<C: FromSortedVec> Generator for RandomCollection<C>
 where
-    C::Item: Ord + Copy + TryFrom<usize>,
+    C::Item: Ord + Copy + TryFrom<usize> + Debug,
     usize: TryFrom<C::Item>,
 {
     type Haystack = Sample<C>;
@@ -115,11 +113,12 @@ impl<T> FromSortedVec for Vec<T> {
     }
 }
 
+/// Generate benchmarks for searching in a collection.
 pub fn search_benchmarks<C, F>(f: F) -> impl IntoBenchmarks
 where
     C: FromSortedVec + 'static,
     F: Fn(&Sample<C>, &C::Item) -> Option<C::Item> + Copy + 'static,
-    C::Item: Copy + Ord + TryFrom<usize>,
+    C::Item: Copy + Ord + TryFrom<usize> + Debug,
     usize: TryFrom<C::Item>,
 {
     BenchmarkMatrix::with_params(SIZES, |size| RandomCollection::<C>::new(size, 1))
@@ -129,7 +128,7 @@ where
 }
 
 pub const SETTINGS: MeasurementSettings = MeasurementSettings {
-    samples_per_haystack: 1_000_000,
+    samples_per_haystack: 50,
     max_iterations_per_sample: 10_000,
     ..DEFAULT_SETTINGS
 };

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,135 @@
+extern crate tango_bench;
+
+use std::{any::type_name, convert::TryFrom, iter, marker::PhantomData};
+use tango_bench::{
+    BenchmarkMatrix, Generator, IntoBenchmarks, MeasurementSettings, DEFAULT_SETTINGS,
+};
+
+const SIZES: [usize; 14] = [
+    8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4069, 8192, 16384, 32768, 65536,
+];
+
+struct Lcg(usize);
+
+impl Lcg {
+    fn next<T: TryFrom<usize>>(&mut self, max_value: usize) -> T {
+        self.0 = self.0.wrapping_mul(1664525).wrapping_add(1013904223);
+        T::try_from((self.0 >> 32) % max_value).ok().unwrap()
+    }
+}
+
+pub struct RandomCollection<C: FromSortedVec> {
+    rng: Lcg,
+    size: usize,
+    name: String,
+    value_dup_factor: usize,
+    phantom: PhantomData<C>,
+}
+
+impl<C: FromSortedVec> RandomCollection<C>
+where
+    C::Item: Ord + Copy + TryFrom<usize>,
+{
+    pub fn new(size: usize, value_dup_factor: usize) -> Self {
+        let type_name = type_name::<C::Item>();
+        let name = if value_dup_factor > 1 {
+            format!("{}/{}/dup-{}", type_name, size, value_dup_factor)
+        } else {
+            format!("{}/{}/nodup", type_name, size)
+        };
+
+        Self {
+            rng: Lcg(0),
+            size,
+            value_dup_factor,
+            name,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<C: FromSortedVec> Generator for RandomCollection<C>
+where
+    C::Item: Ord + Copy + TryFrom<usize>,
+    usize: TryFrom<C::Item>,
+{
+    type Haystack = Sample<C>;
+    type Needle = C::Item;
+
+    fn next_haystack(&mut self) -> Self::Haystack {
+        let vec = generate_sorted_vec(self.size, self.value_dup_factor);
+        let max = usize::try_from(*vec.last().unwrap()).ok().unwrap();
+        Sample {
+            collection: C::from_sorted_vec(vec),
+            max_value: max,
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn next_needle(&mut self, sample: &Self::Haystack) -> Self::Needle {
+        self.rng.next(sample.max_value + 1)
+    }
+
+    fn sync(&mut self, seed: u64) {
+        self.rng = Lcg(seed as usize);
+    }
+}
+
+fn generate_sorted_vec<T>(size: usize, dup_factor: usize) -> Vec<T>
+where
+    T: Ord + Copy + TryFrom<usize>,
+{
+    (0..)
+        .map(|v| 2 * v)
+        .map(|v| T::try_from(v))
+        .map_while(Result::ok)
+        .flat_map(|v| iter::repeat(v).take(dup_factor))
+        .take(size)
+        .collect()
+}
+
+pub struct Sample<C> {
+    collection: C,
+    max_value: usize,
+}
+
+impl<C> AsRef<C> for Sample<C> {
+    fn as_ref(&self) -> &C {
+        &self.collection
+    }
+}
+
+pub trait FromSortedVec {
+    type Item;
+    fn from_sorted_vec(v: Vec<Self::Item>) -> Self;
+}
+
+impl<T> FromSortedVec for Vec<T> {
+    type Item = T;
+
+    fn from_sorted_vec(v: Vec<T>) -> Self {
+        v
+    }
+}
+
+pub fn search_benchmarks<C, F>(f: F) -> impl IntoBenchmarks
+where
+    C: FromSortedVec + 'static,
+    F: Fn(&Sample<C>, &C::Item) -> Option<C::Item> + Copy + 'static,
+    C::Item: Copy + Ord + TryFrom<usize>,
+    usize: TryFrom<C::Item>,
+{
+    BenchmarkMatrix::with_params(SIZES, |size| RandomCollection::<C>::new(size, 1))
+        .add_generators_with_params(SIZES, |size| RandomCollection::<C>::new(size, 16))
+        .add_function("search", f)
+        .into_benchmarks()
+}
+
+pub const SETTINGS: MeasurementSettings = MeasurementSettings {
+    samples_per_haystack: 1_000_000,
+    max_iterations_per_sample: 10_000,
+    ..DEFAULT_SETTINGS
+};

--- a/benches/search_btree.rs
+++ b/benches/search_btree.rs
@@ -1,0 +1,31 @@
+extern crate tango_bench;
+
+use common::{search_benchmarks, FromSortedVec};
+use std::{collections::BTreeSet, iter::FromIterator, ops::Bound};
+use tango_bench::{tango_benchmarks, tango_main};
+
+mod common;
+
+impl<T: Ord> FromSortedVec for BTreeSet<T> {
+    type Item = T;
+
+    fn from_sorted_vec(v: Vec<T>) -> Self {
+        BTreeSet::from_iter(v)
+    }
+}
+
+fn search_btree<T: Copy + Ord>(haystack: &impl AsRef<BTreeSet<T>>, needle: &T) -> Option<T> {
+    haystack
+        .as_ref()
+        .range((Bound::Included(needle), Bound::Unbounded))
+        .next()
+        .copied()
+}
+
+tango_benchmarks!(
+    search_benchmarks(search_btree::<u8>),
+    search_benchmarks(search_btree::<u16>),
+    search_benchmarks(search_btree::<u32>),
+    search_benchmarks(search_btree::<u64>)
+);
+tango_main!(common::SETTINGS);

--- a/benches/search_comparison.rs
+++ b/benches/search_comparison.rs
@@ -1,7 +1,6 @@
 extern crate criterion;
 extern crate num_traits;
 extern crate ordsearch;
-extern crate tango_bench;
 
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, AxisScale, BatchSize, BenchmarkGroup,
@@ -16,12 +15,6 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
-
-/// Because benchmarks are builded with linker flag -rdynamic there should be library entry point defined
-/// in all benchmarks. This is only needed when two harnesses are used.
-mod linker_fix {
-    tango_bench::tango_benchmarks!([]);
-}
 
 const WARM_UP_TIME: Duration = Duration::from_millis(500);
 const MEASUREMENT_TIME: Duration = Duration::from_millis(1000);

--- a/benches/search_comparison.rs
+++ b/benches/search_comparison.rs
@@ -1,6 +1,7 @@
 extern crate criterion;
 extern crate num_traits;
 extern crate ordsearch;
+extern crate tango_bench;
 
 use criterion::{
     criterion_group, criterion_main, measurement::WallTime, AxisScale, BatchSize, BenchmarkGroup,
@@ -15,6 +16,15 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
+
+/// Because benchmarks are builded with linker flag -rdynamic there should be library entry point defined
+/// in all benchmarks. On macOS linker is able to strip all tango_*() FFI functions, because the corresponding
+/// module tango_bench::cli is not used. On Linux it is not possible to strip them, so we need to define
+/// dummy entry point. This is only needed when two harnesses are used.
+#[cfg(target_os = "linux")]
+mod linker_fix {
+    tango_bench::tango_benchmarks!([]);
+}
 
 const WARM_UP_TIME: Duration = Duration::from_millis(500);
 const MEASUREMENT_TIME: Duration = Duration::from_millis(1000);

--- a/benches/search_comparison.rs
+++ b/benches/search_comparison.rs
@@ -18,10 +18,7 @@ use std::{
 };
 
 /// Because benchmarks are builded with linker flag -rdynamic there should be library entry point defined
-/// in all benchmarks. On macOS linker is able to strip all tango_*() FFI functions, because the corresponding
-/// module tango_bench::cli is not used. On Linux it is not possible to strip them, so we need to define
-/// dummy entry point. This is only needed when two harnesses are used.
-#[cfg(target_os = "linux")]
+/// in all benchmarks. This is only needed when two harnesses are used.
 mod linker_fix {
     tango_bench::tango_benchmarks!([]);
 }

--- a/benches/search_ord.rs
+++ b/benches/search_ord.rs
@@ -1,0 +1,31 @@
+#![cfg_attr(feature = "align", feature(fn_align))]
+
+extern crate ordsearch;
+extern crate tango_bench;
+
+use common::{search_benchmarks, FromSortedVec};
+use ordsearch::OrderedCollection;
+use tango_bench::{tango_benchmarks, tango_main};
+
+mod common;
+
+impl<T: Ord> FromSortedVec for OrderedCollection<T> {
+    type Item = T;
+    fn from_sorted_vec(v: Vec<T>) -> Self {
+        OrderedCollection::from_sorted_iter(v)
+    }
+}
+
+#[cfg_attr(feature = "align", repr(align(32)))]
+#[cfg_attr(feature = "align", inline(never))]
+fn search_ord<T: Copy + Ord>(haystack: &impl AsRef<OrderedCollection<T>>, needle: &T) -> Option<T> {
+    haystack.as_ref().find_gte(*needle).copied()
+}
+
+tango_benchmarks!(
+    search_benchmarks(search_ord::<u8>),
+    search_benchmarks(search_ord::<u16>),
+    search_benchmarks(search_ord::<u32>),
+    search_benchmarks(search_ord::<u64>)
+);
+tango_main!(common::SETTINGS);

--- a/benches/search_ord.rs
+++ b/benches/search_ord.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "align", feature(fn_align))]
-
 extern crate ordsearch;
 extern crate tango_bench;
 
@@ -16,8 +14,6 @@ impl<T: Ord> FromSortedVec for OrderedCollection<T> {
     }
 }
 
-#[cfg_attr(feature = "align", repr(align(32)))]
-#[cfg_attr(feature = "align", inline(never))]
 fn search_ord<T: Copy + Ord>(haystack: &impl AsRef<OrderedCollection<T>>, needle: &T) -> Option<T> {
     haystack.as_ref().find_gte(*needle).copied()
 }

--- a/benches/search_vec.rs
+++ b/benches/search_vec.rs
@@ -1,0 +1,24 @@
+extern crate tango_bench;
+
+use common::{search_benchmarks, Sample};
+use tango_bench::{tango_benchmarks, tango_main};
+
+mod common;
+
+fn search_vec<T: Copy + Ord>(haystack: &Sample<Vec<T>>, needle: &T) -> Option<T> {
+    let haystack = haystack.as_ref();
+    haystack
+        .binary_search(needle)
+        .ok()
+        .and_then(|idx| haystack.get(idx))
+        .copied()
+}
+
+tango_benchmarks!(
+    search_benchmarks(search_vec::<u8>),
+    search_benchmarks(search_vec::<u16>),
+    search_benchmarks(search_vec::<u32>),
+    search_benchmarks(search_vec::<u64>)
+);
+
+tango_main!(common::SETTINGS);

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("cargo:rustc-link-arg-benches=-rdynamic");
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-benches=-rdynamic");
+}


### PR DESCRIPTION
For quite some time I've developed a benchmarking harness called [Tango](https://github.com/bazhenov/tango). It is based on [paired testing methodology](https://www.bazhenov.me/posts/paired-benchmarking/). Now I'm confident enough to publish it. Ordsearch in fact was one of the first projects I've tried it on and used for. So this PR is a benchmark implementation of ordsearch on Tango. The main purpose is to provide a performance regression toolkit using GHA.

The main promises of paired testing are:

- convenience – we're estimating a difference in the performance of two algorithms directly which in most cases the thing we need
- sensitivity and speed – because two algorithms are executed simultaneously both algorithms are subject to the same biases the platform has at the moment. Therefore we can estimate performance differences more accurately or spend less time on achieving the same level of precision.
- performance regression testing – using paired testing tango allows us to compare not only 2 algorithms in the same code base but also 2 versions of the same algorithm from different VCS commits/branches ([ex.](https://github.com/bazhenov/tango/actions/runs/7139451999/job/19442827322#step:7:10)). This allows to do quite sensitive performance regression testing. In my experience so far it can quite confidently find regressions as low as 5%..

## Sensitivity

I've done some [experiments](https://github.com/bazhenov/tango/blob/dev/scripts/ordsearch.sh) on an AWS c2.medium instance. I ran a single test `u32/1024/nodup` in both criterion and tango in a loop 400 times which took several hours. Here are 80% confidence intervals on the performance difference between `OrderedCollection` and `Vec` as measured by tango and criterion.

![ordsearch-80CI](https://github.com/jonhoo/ordsearch/assets/36286/39d51cfe-db94-4b00-b22e-6d93e85a9150)

Even using a fraction of a second Tango can provide tighter intervals.

Here are 100% CI (whiskers are showing minimum and maximum values)

![ordsearch-min-max](https://github.com/jonhoo/ordsearch/assets/36286/6a3dc0c2-8f10-4140-bddb-9ce878a33d86)

Here the results are comparable between Tango and Criterion, but Tango requires much less time. Even 0.1s is enough to get a coarse estimate which is very useful when experimenting in development.

## Regression testing

Tango builds an executable benchmark which is at the same time a dynamically linked library. This way 2 versions of the same code can be loaded in the address space and benchmarked in a paired way. The algorithm is quite simple:

- checkout branch
- build benchmarks and export then (I built [cargo-export](https://github.com/bazhenov/cargo-export) for that)
- checkout main branch
- build benchmark and run it passing branch executable as an argument `./main-bench compare ./branch-bench`

I've added a benchmarking workflow for GitHub, but it needs to be debugged and streamlined which is possible only after PR is open (GHA doesn't work in forks).