### PR TITLE
Optimized Eytzinger layout & memory prefetch

### DIFF
--- a/benches/search_comparison.rs
+++ b/benches/search_comparison.rs
@@ -38,7 +38,8 @@ where
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
 
     let sizes = [
-        8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4069, 8192, 16384, 32768, 65536,
+        8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4069, 8192, 16384, 32768, 65536, 1048576,
+        10485760,
     ];
 
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,11 @@ impl<T: Ord> OrderedCollection<T> {
     //   2^k * i
     //
     // this follows from the fact that the leftmost immediate child of node i is at 2i by
-    // recursively expanding i. if you're curious, the rightmost child is at:
+    // recursively expanding i. Note that the original paper uses 0-based indexing (`2i + 1`/`2i + 2`) while we
+    // use 1-based indexing (`2i`/`2i + 1`). This is because of performance reasons (see:
+    // [Optimized Eytzinger layout & memory prefetch](https://github.com/jonhoo/ordsearch/pull/27)).
+    //
+    // If you're curious, the rightmost child is at:
     //
     //   2^k * i + 2^k - 1
     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ impl<T: Ord> OrderedCollection<T> {
         let mut i = 1;
 
         let mask = prefetch_mask(self.items.len());
-        // the search loop is proven to be CPU-backend and not memory bound when using prefetch. So offset part
+        // the search loop is arithmetic-bound, not memory-bound when using prefetch. So offset part
         // of prefetch address is intentionally not masked, it allows to do less arithmetic in the loop.
         // It doesn't affect masking much because `Self::OFFSET` is just half of a cache line.
         let prefetch_ptr = self.items.as_ptr().wrapping_add(Self::OFFSET);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,7 @@ impl<T: Ord> OrderedCollection<T> {
         // the search loop is arithmetic-bound, not memory-bound when using prefetch. So offset part
         // of prefetch address is intentionally not masked, it allows to do less arithmetic in the loop.
         // It doesn't affect masking much because `Self::OFFSET` is just half of a cache line.
+        // (see: [Optimized Eytzinger layout & memory prefetch](https://github.com/jonhoo/ordsearch/pull/27))
         let prefetch_ptr = self.items.as_ptr().wrapping_add(Self::OFFSET);
 
         while i < self.items.len() {


### PR DESCRIPTION
When using prefetch, the search loop became heavily CPU-backend bound. Basically, prefetch offset computation logic is competing with search logic itself for ALU.

This PR contains 2 optimizations of the search loop that allows us to do the same work using fewer arithmetics and brings 5-30% of the performance for `OrderedCollection` depending on the type and array size.

## Modified Eytzinger layout

The original navigation rules for Eytzinger are `2i + 1`/`2i + 2`. But if we put the root element in the 1st element in the array instead of 0th, iteration rules becomes `2i`/`2i+1`. It helps in several ways:

1. simpler navigation arithmetics
1. simpler prefetch offset – it is just half of a cache line
1. greatly simpler branchless index decode arithmetics

## Partially masked prefetch

The idea of a masked prefetch was initially described in [1]. The motivation is the following

> With some processors (the AMD Phenom II, Intel Celeron J1900, and Intel E3-1230 are examples) the code that does explicit prefetching is much slower, especially for smaller values of n. This seems to be due to executing prefetch instructions that attempt to prefetch data outside the input array. Although the documentation for the __builtin_prefetch() instruction specifically allows prefetching invalid addresses, this seems to cause a significant performance hit on these processors. On such architectures, a workaround is to use a bit-mask to ensure that we never prefetch an address outside the input array

Indeed the described effect was detectable on every CPU I've run the tests on. However, after the enormous amount of days spent on PMU analysis, I tend to believe the explanation is not correct.

The prefetch logic is approximately doubling the amount of arithmetic that needs to be performed per each loop iteration. For large arrays when we're memory bound it pays off, but for smaller `n` it hurts the performance. There is clear evidence (Intel VTune/perf) that for small arrays the loop is backend-bound with high port 0, 1, and 5 utilization (which are connected to ALU on Intel) (see. [Understanding CPU port contention](https://easyperf.net/blog/2018/03/21/port-contention)).

Now the reason masking helps, I believe, is not because of some microarchitecture specifics of some CPUs, but because on the last iteration of a search loop masked approach allows to prefetch first elements of the array helping subsequent searches to perform faster. Essentially, it is a cheap version of `offset % size`

The optimization implemented is moving offset out of masking.

```
current:   prefetch = base + (multiplier * i + offset) & mask
optimized: prefetch = base + offset + (multiplier * i) & mask
```

It allows us to make an offset part of the base address and move it out of the loop. Although the optimized approach formally produces slightly different addresses this optimization works quite nicely with the previous one, because after Eytzinger layout optimization offset is always half a cache line. So we're always prefetching addresses not further than half a cache line from the original approach.

I also added some large array size benchmarks to test that performance doesn't get worse on workloads that doesn't fit in cache.

[1]: [ARRAY LAYOUTS FOR COMPARISON-BASED SEARCHING](https://arxiv.org/pdf/1509.05053v1.pdf)



<details>
  <summary>Criterion results (AWS c1.medium: Intel Xeon E5-2651 v2 @ 1.80GHz)</summary>

```
Search u8/ordsearch/8   time:   [23.503 ns 23.521 ns 23.539 ns]
                        change: [-16.089% -15.614% -14.965%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/16  time:   [23.219 ns 23.242 ns 23.273 ns]
                        change: [-13.184% -12.386% -11.456%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/32  time:   [25.123 ns 25.164 ns 25.207 ns]
                        change: [-11.313% -10.526% -9.3601%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/64  time:   [26.657 ns 26.670 ns 26.685 ns]
                        change: [-14.855% -14.052% -13.202%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/128 time:   [28.850 ns 28.870 ns 28.897 ns]
                        change: [-15.515% -14.757% -13.771%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/256 time:   [31.479 ns 31.496 ns 31.516 ns]
                        change: [-18.131% -17.705% -16.973%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/512 time:   [34.661 ns 34.680 ns 34.703 ns]
                        change: [-19.898% -19.542% -18.967%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/1024
                        time:   [38.093 ns 38.184 ns 38.367 ns]
                        change: [-21.644% -21.185% -20.680%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/2048
                        time:   [42.199 ns 42.232 ns 42.277 ns]
                        change: [-21.741% -21.400% -20.912%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/4069
                        time:   [87.869 ns 87.925 ns 87.979 ns]
                        change: [+49.039% +49.385% +49.683%] (p = 0.00 < 0.05)
                        Performance has regressed.
Search u8/ordsearch/8192
                        time:   [51.234 ns 51.267 ns 51.305 ns]
                        change: [-19.556% -19.408% -19.282%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/16384
                        time:   [55.749 ns 55.794 ns 55.845 ns]
                        change: [-19.294% -19.077% -18.719%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/32768
                        time:   [60.393 ns 60.420 ns 60.446 ns]
                        change: [-18.621% -18.500% -18.395%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u8/ordsearch/65536
                        time:   [64.436 ns 64.479 ns 64.521 ns]
                        change: [-18.751% -18.609% -18.437%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/8
                        time:   [19.105 ns 19.126 ns 19.150 ns]
                        change: [-5.4435% -4.4330% -3.5011%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/16
                        time:   [21.618 ns 22.583 ns 23.681 ns]
                        change: [-6.5071% -3.6402% -0.6330%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Search (with duplicates) u8/ordsearch/32
                        time:   [23.742 ns 23.758 ns 23.778 ns]
                        change: [-12.656% -11.565% -10.500%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/64
                        time:   [26.071 ns 26.137 ns 26.275 ns]
                        change: [-14.801% -14.048% -13.141%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/128
                        time:   [28.555 ns 28.578 ns 28.608 ns]
                        change: [-18.574% -17.865% -16.971%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/256
                        time:   [31.461 ns 31.476 ns 31.494 ns]
                        change: [-24.880% -24.384% -23.773%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/512
                        time:   [34.645 ns 34.673 ns 34.708 ns]
                        change: [-33.630% -33.133% -32.397%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/1024
                        time:   [38.087 ns 38.135 ns 38.213 ns]
                        change: [-43.187% -42.786% -42.323%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/2048
                        time:   [42.213 ns 42.231 ns 42.249 ns]
                        change: [-23.614% -22.205% -21.299%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/4069
                        time:   [87.734 ns 87.781 ns 87.829 ns]
                        change: [+48.902% +49.264% +49.683%] (p = 0.00 < 0.05)
                        Performance has regressed.
Search (with duplicates) u8/ordsearch/8192
                        time:   [51.130 ns 51.151 ns 51.171 ns]
                        change: [-19.684% -19.575% -19.467%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/16384
                        time:   [55.654 ns 55.682 ns 55.713 ns]
                        change: [-19.424% -19.258% -19.077%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/32768
                        time:   [60.351 ns 60.374 ns 60.399 ns]
                        change: [-18.547% -18.432% -18.298%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u8/ordsearch/65536
                        time:   [64.457 ns 64.503 ns 64.564 ns]
                        change: [-18.732% -18.475% -18.265%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/8  time:   [23.344 ns 23.369 ns 23.398 ns]
                        change: [-13.889% -13.157% -12.274%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/16 time:   [23.239 ns 23.249 ns 23.260 ns]
                        change: [-13.005% -12.249% -11.346%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/32 time:   [25.009 ns 25.034 ns 25.060 ns]
                        change: [-11.576% -11.035% -10.324%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/64 time:   [26.804 ns 26.829 ns 26.859 ns]
                        change: [-22.114% -19.758% -17.401%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/128
                        time:   [28.964 ns 28.984 ns 29.005 ns]
                        change: [-15.604% -14.900% -14.087%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/256
                        time:   [31.678 ns 31.699 ns 31.729 ns]
                        change: [-18.579% -17.962% -17.152%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/512
                        time:   [34.922 ns 34.940 ns 34.964 ns]
                        change: [-19.774% -19.245% -18.581%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/1024
                        time:   [38.697 ns 38.730 ns 38.779 ns]
                        change: [-20.148% -19.642% -18.694%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/2048
                        time:   [43.072 ns 43.086 ns 43.102 ns]
                        change: [-51.495% -51.098% -50.559%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/4069
                        time:   [47.747 ns 47.760 ns 47.774 ns]
                        change: [-19.074% -18.646% -18.052%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/8192
                        time:   [52.015 ns 52.057 ns 52.117 ns]
                        change: [-18.345% -17.943% -17.483%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/16384
                        time:   [56.869 ns 56.894 ns 56.923 ns]
                        change: [-17.359% -17.120% -16.810%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/32768
                        time:   [61.732 ns 61.785 ns 61.856 ns]
                        change: [-16.698% -16.539% -16.405%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u16/ordsearch/65536
                        time:   [66.928 ns 66.964 ns 67.000 ns]
                        change: [-15.343% -15.248% -15.160%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/8
                        time:   [18.971 ns 18.977 ns 18.984 ns]
                        change: [-4.8995% -3.8263% -2.5950%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/16
                        time:   [21.079 ns 21.087 ns 21.097 ns]
                        change: [-8.2803% -7.2503% -6.0791%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/32
                        time:   [24.012 ns 24.030 ns 24.055 ns]
                        change: [-11.206% -10.511% -9.8690%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/64
                        time:   [26.275 ns 26.289 ns 26.305 ns]
                        change: [-14.300% -13.610% -12.961%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/128
                        time:   [28.709 ns 28.728 ns 28.752 ns]
                        change: [-18.248% -17.483% -16.765%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/256
                        time:   [31.498 ns 31.522 ns 31.550 ns]
                        change: [-20.299% -19.861% -19.261%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/512
                        time:   [34.836 ns 34.852 ns 34.874 ns]
                        change: [-21.950% -21.426% -20.295%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/1024
                        time:   [38.644 ns 38.660 ns 38.680 ns]
                        change: [-22.412% -21.925% -21.279%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/2048
                        time:   [43.064 ns 43.097 ns 43.141 ns]
                        change: [-51.222% -50.738% -50.145%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/4069
                        time:   [49.101 ns 49.114 ns 49.127 ns]
                        change: [-41.458% -41.222% -40.862%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/8192
                        time:   [52.067 ns 52.104 ns 52.161 ns]
                        change: [-20.205% -19.781% -19.440%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/16384
                        time:   [56.455 ns 56.495 ns 56.533 ns]
                        change: [-19.662% -19.385% -18.969%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/32768
                        time:   [60.904 ns 60.958 ns 61.024 ns]
                        change: [-20.077% -19.266% -18.740%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u16/ordsearch/65536
                        time:   [65.540 ns 65.605 ns 65.683 ns]
                        change: [-21.171% -20.949% -20.715%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/8  time:   [23.178 ns 23.189 ns 23.199 ns]
                        change: [-17.292% -16.240% -15.279%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/16 time:   [23.698 ns 23.710 ns 23.723 ns]
                        change: [-12.924% -12.190% -11.411%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/32 time:   [24.817 ns 24.834 ns 24.852 ns]
                        change: [-11.449% -10.651% -9.7005%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/64 time:   [26.544 ns 26.563 ns 26.583 ns]
                        change: [-12.551% -11.708% -10.874%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/128
                        time:   [28.801 ns 28.833 ns 28.871 ns]
                        change: [-14.124% -13.395% -12.590%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/256
                        time:   [31.504 ns 31.517 ns 31.531 ns]
                        change: [-16.634% -15.870% -14.937%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/512
                        time:   [34.491 ns 34.504 ns 34.517 ns]
                        change: [-19.045% -18.283% -17.515%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/1024
                        time:   [38.517 ns 38.559 ns 38.611 ns]
                        change: [-18.390% -18.018% -17.410%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/2048
                        time:   [43.816 ns 43.835 ns 43.857 ns]
                        change: [-51.358% -51.200% -51.026%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/4069
                        time:   [47.491 ns 47.518 ns 47.551 ns]
                        change: [-18.131% -17.854% -17.658%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/8192
                        time:   [52.106 ns 52.146 ns 52.185 ns]
                        change: [-16.814% -16.380% -16.114%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/16384
                        time:   [56.739 ns 56.799 ns 56.852 ns]
                        change: [-16.685% -16.318% -16.025%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/32768
                        time:   [61.133 ns 61.159 ns 61.188 ns]
                        change: [-16.325% -16.196% -16.069%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u32/ordsearch/65536
                        time:   [66.084 ns 66.139 ns 66.186 ns]
                        change: [-15.993% -15.843% -15.682%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/8
                        time:   [18.811 ns 18.821 ns 18.833 ns]
                        change: [-4.3354% -3.0835% -1.7193%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/16
                        time:   [21.399 ns 21.413 ns 21.428 ns]
                        change: [-4.0088% -2.8282% -1.5666%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/32
                        time:   [23.765 ns 23.792 ns 23.819 ns]
                        change: [-10.838% -9.9325% -9.0563%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/64
                        time:   [25.988 ns 26.005 ns 26.023 ns]
                        change: [-14.435% -13.591% -12.752%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/128
                        time:   [28.523 ns 28.546 ns 28.570 ns]
                        change: [-17.584% -16.736% -15.816%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/256
                        time:   [31.372 ns 31.384 ns 31.396 ns]
                        change: [-19.482% -18.741% -17.970%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/512
                        time:   [34.414 ns 34.429 ns 34.443 ns]
                        change: [-22.166% -21.372% -20.262%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/1024
                        time:   [38.466 ns 38.505 ns 38.550 ns]
                        change: [-21.790% -21.064% -20.121%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/2048
                        time:   [42.833 ns 42.893 ns 42.997 ns]
                        change: [-22.648% -22.047% -21.440%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/4069
                        time:   [46.072 ns 46.143 ns 46.217 ns]
                        change: [-15.240% -14.499% -13.899%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/8192
                        time:   [51.491 ns 51.543 ns 51.595 ns]
                        change: [-19.789% -19.416% -19.090%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/16384
                        time:   [56.189 ns 56.223 ns 56.258 ns]
                        change: [-18.740% -18.606% -18.459%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/32768
                        time:   [60.569 ns 60.629 ns 60.694 ns]
                        change: [-18.623% -18.458% -18.326%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u32/ordsearch/65536
                        time:   [66.203 ns 66.240 ns 66.284 ns]
                        change: [-17.147% -16.963% -16.781%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/8  time:   [22.487 ns 22.497 ns 22.507 ns]
                        change: [-18.961% -17.663% -16.546%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/16 time:   [22.186 ns 22.197 ns 22.209 ns]
                        change: [-18.950% -18.184% -17.456%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/32 time:   [24.102 ns 24.126 ns 24.154 ns]
                        change: [-12.493% -11.609% -10.834%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/64 time:   [26.439 ns 26.459 ns 26.486 ns]
                        change: [-10.484% -9.6488% -8.8502%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/128
                        time:   [28.792 ns 28.809 ns 28.830 ns]
                        change: [-11.502% -10.540% -9.5239%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/256
                        time:   [31.445 ns 31.455 ns 31.466 ns]
                        change: [-13.502% -12.648% -11.679%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/512
                        time:   [34.553 ns 34.567 ns 34.583 ns]
                        change: [-14.707% -13.913% -12.929%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/1024
                        time:   [38.454 ns 38.472 ns 38.493 ns]
                        change: [-15.960% -15.330% -14.897%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/2048
                        time:   [42.534 ns 42.562 ns 42.591 ns]
                        change: [-15.641% -14.998% -14.380%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/4069
                        time:   [47.260 ns 47.337 ns 47.454 ns]
                        change: [-15.849% -15.276% -14.734%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/8192
                        time:   [51.648 ns 51.700 ns 51.758 ns]
                        change: [-15.096% -14.341% -13.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/16384
                        time:   [57.155 ns 57.954 ns 58.985 ns]
                        change: [-12.047% -10.208% -8.1803%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/32768
                        time:   [61.197 ns 61.269 ns 61.372 ns]
                        change: [-13.346% -13.176% -12.958%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u64/ordsearch/65536
                        time:   [67.235 ns 67.261 ns 67.288 ns]
                        change: [-11.961% -11.813% -11.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/8
                        time:   [18.171 ns 18.180 ns 18.189 ns]
                        change: [-6.0709% -4.9872% -3.9221%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/16
                        time:   [20.430 ns 20.442 ns 20.455 ns]
                        change: [-5.3305% -4.3103% -3.2983%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/32
                        time:   [23.220 ns 23.247 ns 23.277 ns]
                        change: [-11.160% -10.187% -9.2876%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/64
                        time:   [25.973 ns 25.981 ns 25.990 ns]
                        change: [-12.550% -11.694% -10.989%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/128
                        time:   [28.565 ns 28.587 ns 28.611 ns]
                        change: [-15.252% -14.413% -13.599%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/256
                        time:   [31.329 ns 31.341 ns 31.354 ns]
                        change: [-15.470% -14.679% -13.944%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/512
                        time:   [34.529 ns 34.552 ns 34.582 ns]
                        change: [-16.177% -15.445% -14.742%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/1024
                        time:   [38.399 ns 38.418 ns 38.434 ns]
                        change: [-16.805% -16.114% -15.551%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/2048
                        time:   [42.573 ns 42.591 ns 42.609 ns]
                        change: [-16.748% -16.143% -15.549%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/4069
                        time:   [44.937 ns 44.989 ns 45.053 ns]
                        change: [-11.684% -11.128% -10.655%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/8192
                        time:   [51.440 ns 51.476 ns 51.508 ns]
                        change: [-16.414% -15.940% -15.438%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/16384
                        time:   [57.246 ns 58.725 ns 60.402 ns]
                        change: [-14.573% -13.461% -12.046%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/32768
                        time:   [61.584 ns 61.663 ns 61.762 ns]
                        change: [-14.492% -14.302% -14.086%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u64/ordsearch/65536
                        time:   [70.720 ns 70.761 ns 70.812 ns]
                        change: [-20.465% -20.160% -19.762%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/8 time:   [27.444 ns 27.468 ns 27.501 ns]
                        change: [-11.974% -11.466% -10.617%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/16
                        time:   [29.052 ns 29.073 ns 29.095 ns]
                        change: [-12.279% -11.510% -10.816%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/32
                        time:   [31.794 ns 31.807 ns 31.821 ns]
                        change: [-13.199% -12.383% -11.434%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/64
                        time:   [36.394 ns 36.430 ns 36.472 ns]
                        change: [-12.189% -11.474% -10.828%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/128
                        time:   [41.146 ns 41.164 ns 41.183 ns]
                        change: [-12.972% -12.121% -11.192%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/256
                        time:   [47.872 ns 47.917 ns 47.978 ns]
                        change: [-12.217% -11.657% -11.220%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/512
                        time:   [54.686 ns 54.728 ns 54.775 ns]
                        change: [-10.486% -9.8481% -9.2713%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/1024
                        time:   [61.694 ns 61.711 ns 61.729 ns]
                        change: [-9.3675% -8.6761% -8.0414%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/2048
                        time:   [69.285 ns 69.311 ns 69.340 ns]
                        change: [-33.668% -32.595% -31.391%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/4069
                        time:   [76.499 ns 76.543 ns 76.598 ns]
                        change: [-7.8447% -7.2016% -6.5054%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/8192
                        time:   [84.074 ns 84.105 ns 84.143 ns]
                        change: [-9.7154% -9.1420% -8.7833%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/16384
                        time:   [92.405 ns 92.429 ns 92.456 ns]
                        change: [-10.436% -10.191% -9.9630%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/32768
                        time:   [101.45 ns 101.50 ns 101.55 ns]
                        change: [-1.8435% -1.5730% -1.2705%] (p = 0.00 < 0.05)
                        Performance has improved.
Search u128/ordsearch/65536
                        time:   [106.00 ns 106.10 ns 106.23 ns]
                        change: [-22.521% -22.170% -21.851%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/8
                        time:   [23.263 ns 23.272 ns 23.283 ns]
                        change: [-0.9841% +0.4574% +2.4031%] (p = 0.70 > 0.05)
                        No change in performance detected.
Search (with duplicates) u128/ordsearch/16
                        time:   [26.850 ns 26.864 ns 26.882 ns]
                        change: [-3.4301% -2.1704% -0.5426%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Search (with duplicates) u128/ordsearch/32
                        time:   [30.670 ns 30.688 ns 30.711 ns]
                        change: [-7.0753% -6.1636% -5.1984%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/64
                        time:   [35.453 ns 35.469 ns 35.488 ns]
                        change: [-13.147% -12.472% -11.580%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/128
                        time:   [40.859 ns 40.871 ns 40.883 ns]
                        change: [-19.287% -17.281% -15.266%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/256
                        time:   [47.633 ns 47.649 ns 47.668 ns]
                        change: [-11.886% -11.388% -10.588%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/512
                        time:   [54.556 ns 54.580 ns 54.608 ns]
                        change: [-10.751% -10.201% -9.3296%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/1024
                        time:   [61.614 ns 61.645 ns 61.681 ns]
                        change: [-9.9567% -9.5916% -9.1567%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/2048
                        time:   [69.248 ns 69.270 ns 69.294 ns]
                        change: [-9.0006% -8.6114% -8.2403%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/4069
                        time:   [72.170 ns 72.210 ns 72.264 ns]
                        change: [-4.9466% -4.5961% -4.1616%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/8192
                        time:   [83.212 ns 83.262 ns 83.319 ns]
                        change: [-7.5635% -7.1654% -6.5480%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/16384
                        time:   [91.487 ns 91.522 ns 91.560 ns]
                        change: [-8.2649% -8.0395% -7.8410%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/32768
                        time:   [103.29 ns 103.33 ns 103.38 ns]
                        change: [-2.2344% -1.8879% -1.6028%] (p = 0.00 < 0.05)
                        Performance has improved.
Search (with duplicates) u128/ordsearch/65536
                        time:   [111.39 ns 111.48 ns 111.61 ns]
                        change: [-7.5036% -7.2322% -6.9782%] (p = 0.00 < 0.05)
                        Performance has improved.

```
</details>