### PR TITLE
OrderedCollection iterator and Vec conversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,7 @@ impl<T: Ord> OrderedCollection<T> {
     /// values.sort();
     /// assert_eq!(values, expected);
     /// ```
-    pub fn iter(&self) -> impl Iterator<Item = &T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter { coll: self, idx: 0 }
     }
 }
@@ -438,6 +438,15 @@ impl<T> OrderedCollection<T> {
     }
 }
 
+impl<'a, T: Ord> IntoIterator for &'a OrderedCollection<T> {
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl<T> IntoIterator for OrderedCollection<T> {
     type Item = T;
     type IntoIter = alloc::vec::IntoIter<T>;
@@ -447,7 +456,10 @@ impl<T> IntoIterator for OrderedCollection<T> {
     }
 }
 
-struct Iter<'a, T> {
+/// Immutable iterator over elements in a [`OrderedCollection`]
+///
+/// Created by [`OrderedCollection::iter()`].
+pub struct Iter<'a, T> {
     coll: &'a OrderedCollection<T>,
     idx: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,9 +458,9 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.idx += 1;
         if self.idx < self.coll.items.len() {
+            let value = &self.coll.items[self.idx];
             // SAFETY: i > 0, so only initialized items are accessed
             // SAFETY: i < self.coll.items.len() so no out-of-bounds access
-            let value = &self.coll.items[self.idx];
             Some(unsafe { value.assume_init_ref() })
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,7 +613,7 @@ mod tests {
     #[test]
     fn check_into_iter_empty() {
         let values = OrderedCollection::<u32>::from(vec![]);
-        assert!(Vec::from(values).is_empty());
+        assert_eq!(Vec::from(values), vec![]);
     }
 
     #[test]
@@ -630,7 +630,7 @@ mod tests {
     #[test]
     fn check_iter_empty() {
         let values = OrderedCollection::<u32>::from(vec![]);
-        assert!(values.iter().next().is_none());
+        assert_eq!(values.iter().next(), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,6 +611,29 @@ mod tests {
     }
 
     #[test]
+    fn check_into_iter_empty() {
+        let values = OrderedCollection::<u32>::from(vec![]);
+        assert!(Vec::from(values).is_empty());
+    }
+
+    #[test]
+    fn check_iter() {
+        let expected = vec![1, 2, 4, 8, 16, 32, 64, 128, 256];
+        let mut values = OrderedCollection::from_sorted_iter(expected.clone())
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        values.sort();
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn check_iter_empty() {
+        let values = OrderedCollection::<u32>::from(vec![]);
+        assert!(values.iter().next().is_none());
+    }
+
+    #[test]
     fn check_mask() {
         assert_eq!(prefetch_mask(0), 0b000);
         assert_eq!(prefetch_mask(1), 0b001);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,7 +415,7 @@ impl<T: Ord> OrderedCollection<T> {
     }
 }
 
-impl<T: Clone> OrderedCollection<T> {
+impl<T> OrderedCollection<T> {
     /// Copies all elemenets into a new [`Vec`] in unspecified order
     ///
     /// # Examples
@@ -438,7 +438,7 @@ impl<T: Clone> OrderedCollection<T> {
     }
 }
 
-impl<T: Clone> IntoIterator for OrderedCollection<T> {
+impl<T> IntoIterator for OrderedCollection<T> {
     type Item = T;
     type IntoIter = alloc::vec::IntoIter<T>;
 
@@ -468,7 +468,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-impl<T: Clone> From<OrderedCollection<T>> for Vec<T> {
+impl<T> From<OrderedCollection<T>> for Vec<T> {
     fn from(value: OrderedCollection<T>) -> Self {
         value.into_vec()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,11 +597,9 @@ mod tests {
     #[test]
     fn check_into_iter() {
         let expected = vec![1, 2, 4, 8, 16, 32, 64, 128, 256];
-        let x = OrderedCollection::from_sorted_iter(expected.clone());
-        let mut values = vec![];
-        for value in x {
-            values.push(value);
-        }
+        let mut values = OrderedCollection::from_sorted_iter(expected.clone())
+            .into_iter()
+            .collect::<Vec<_>>();
         values.sort();
         assert_eq!(values, expected);
     }


### PR DESCRIPTION
PR regarding https://github.com/jonhoo/ordsearch/pull/27#issuecomment-1879672446.

This implementation provides:

- `OrderedCollection::to_vec()`
- `OrderedCollection::iter()`
- `From` implementation for converting `OrderedCollection` to `Vec`

The original plan of implementing `into_iter()` doesn't work. We cannot implement `into_iter()` for `OC` because we cannot move out of `self.items` because `OC` implements custom `Drop`. So we are forced to create a copy of items anyway. In this case If the user wants data in a `Vec`, all items will be copied twice when using `into_iter()`. In this case IMO it is more appropriate to implement `to_vec()`.